### PR TITLE
Removed sleep time and added Semaphore

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -72,6 +72,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +136,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -202,6 +218,7 @@ name = "rust-test"
 version = "0.1.0"
 dependencies = [
  "mimalloc",
+ "num_cpus",
  "tokio",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 
 [dependencies]
 mimalloc = "0.1.46"
+num_cpus = "1.16.0"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,53 +1,55 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use std::{collections::HashMap, thread, time::Duration};
-use tokio::{task::JoinSet, time::Instant};
+use std::{collections::HashMap, num::NonZeroUsize, sync::Arc, time::Duration};
+use tokio::{sync::Semaphore, task::JoinSet, time::Instant};
 
 const TASKS_NUM: u32 = 100_000;
 const ITEMS_NUM: u32 = 10_000;
-const TASKS_IN_BUNCH: u32 = 10;
-const TIME_BETWEEN_BUNCHES_MS: u64 = 1;
 
 struct SomeData {
     name: String,
     num: u32,
 }
 
-async fn run_test() {
+fn test_task() -> Duration {
+    let task_start = Instant::now();
+    let mut map = HashMap::new();
+    let mut _sum: u64 = 0;
+
+    for j in 0..ITEMS_NUM {
+        let name = j.to_string(); // same performance: format!("{}", j);
+
+        map.insert(
+            name.clone(),
+            SomeData {
+                name: name.clone(),
+                num: j,
+            },
+        );
+
+        let val = map.get(&name);
+        if let Some(value) = val {
+            if value.name == name {
+                _sum += value.num as u64;
+            }
+        }
+    }
+    task_start.elapsed()
+}
+
+async fn run_test(task_mult: NonZeroUsize) {
     let start = Instant::now();
     let mut join_set = JoinSet::new();
+    let sem = Arc::new(Semaphore::new(num_cpus::get() * task_mult.get()));
 
-    for task_idx in 0..TASKS_NUM {
-        join_set.spawn(async move {
-            let task_start = Instant::now();
-            let mut map = HashMap::new();
-            let mut _sum: u64 = 0;
+    let test_task_fn = async |sem: Arc<Semaphore>| {
+        let _permit = sem.acquire_owned().await;
+        test_task()
+    };
 
-            for j in 0..ITEMS_NUM {
-                let name = j.to_string(); // same performance: format!("{}", j);
-
-                map.insert(
-                    name.clone(),
-                    SomeData {
-                        name: name.clone(),
-                        num: j,
-                    },
-                );
-
-                let val = map.get(&name);
-                if let Some(value) = val {
-                    if value.name == name {
-                        _sum += value.num as u64;
-                    }
-                }
-            }
-            return task_start.elapsed();
-        });
-
-        if task_idx % TASKS_IN_BUNCH == 0 {
-            thread::sleep(Duration::from_millis(TIME_BETWEEN_BUNCHES_MS));
-        }
+    for _ in 0..TASKS_NUM {
+        join_set.spawn(test_task_fn(sem.clone()));
     }
 
     let mut num_results = 0;
@@ -79,7 +81,8 @@ async fn run_test() {
 
 #[tokio::main]
 async fn main() {
-    run_test().await;
-    run_test().await;
-    run_test().await;
+    run_test(NonZeroUsize::MIN).await;
+    run_test(NonZeroUsize::MIN).await;
+    run_test(NonZeroUsize::new(5).unwrap()).await;
+    run_test(NonZeroUsize::new(10).unwrap()).await;
 }


### PR DESCRIPTION
Removed sleep timer as it was not necessary, added functionality of Semaphore to match your Go program

Before: 
```
- finished in 35.3461538s, task avg 1.211893ms, min 1.0149ms, max 112.3358ms
- finished in 35.6986491s, task avg 1.211761ms, min 1.0199ms, max 69.105ms
- finished in 34.3052809s, task avg 1.203648ms, min 1.0198ms, max 36.0502ms
```


After:
```
- finished in 33.5618998s, task avg 1.209623ms, min 1.0107ms, max 62.1091ms
- finished in 31.4463629s, task avg 1.136508ms, min 1.0116ms, max 33.6175ms
- finished in 31.5273688s, task avg 1.139639ms, min 1.0101ms, max 29.6652ms
- finished in 33.5166868s, task avg 1.205907ms, min 1.0094ms, max 57.3404ms
```