### PR TITLE
additional changes for optimization

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -18,6 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +64,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +88,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +123,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
@@ -158,6 +211,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +276,8 @@ dependencies = [
 name = "rust-test"
 version = "0.1.0"
 dependencies = [
+ "ahash",
+ "compact_str",
  "mimalloc",
  "num_cpus",
  "tokio",
@@ -227,6 +288,18 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -264,6 +337,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -310,6 +389,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -389,3 +474,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+ahash = "0.8.11"
+compact_str = "0.9.0"
 mimalloc = "0.1.46"
 num_cpus = "1.16.0"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,24 +1,26 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use std::{collections::HashMap, num::NonZeroUsize, sync::Arc, time::Duration};
+use ahash::{HashMap, HashMapExt};
+use compact_str::{CompactString, ToCompactString};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 use tokio::{sync::Semaphore, task::JoinSet, time::Instant};
 
 const TASKS_NUM: u32 = 100_000;
 const ITEMS_NUM: u32 = 10_000;
 
 struct SomeData {
-    name: String,
+    name: CompactString,
     num: u32,
 }
 
 fn test_task() -> Duration {
     let task_start = Instant::now();
-    let mut map = HashMap::new();
+    let mut map = HashMap::with_capacity(ITEMS_NUM.try_into().unwrap());
     let mut _sum: u64 = 0;
 
     for j in 0..ITEMS_NUM {
-        let name = j.to_string(); // same performance: format!("{}", j);
+        let name = j.to_compact_string();
 
         map.insert(
             name.clone(),


### PR DESCRIPTION
Added some additional changes to the file: 

```ahash = "0.8.11"```
 is a more efficient hashing algorithm than the default one used in std::HashMap; because it is able to take advantage of AES instruction. [Read more here](https://github.com/tkaitchuck/aHash). Also includes benchmarks for additional hashers.

```compact_str = "0.9.0"```
a more efficient way to store strings directly on the stack instead of heap allocation. [Read more here](https://github.com/ParkMyCar/compact_str)

Original: 

```
- finished in 33.5618998s, task avg 1.209623ms, min 1.0107ms, max 62.1091ms
- finished in 31.4463629s, task avg 1.136508ms, min 1.0116ms, max 33.6175ms
- finished in 31.5273688s, task avg 1.139639ms, min 1.0101ms, max 29.6652ms
- finished in 33.5166868s, task avg 1.205907ms, min 1.0094ms, max 57.3404ms
```

After the few changes: 

```
- finished in 23.9794508s, task avg 890.473µs, min 633µs, max 56.4037ms
- finished in 22.0231254s, task avg 821.608µs, min 632.3µs, max 40.4787ms
- finished in 20.2079099s, task avg 757.14µs, min 634.9µs, max 44.6473ms
- finished in 23.5560827s, task avg 874.619µs, min 637.7µs, max 80.4039ms
```

For extra optimization I preallocated the **HashMap::with_capacity** of each item, I know you said you didn't ideally want this, but for the sake of showing benchmarks worth noting:

After capacity changes:
```
- finished in 13.4907308s, task avg 512.195µs, min 454.6µs, max 32.6919ms
- finished in 13.6798834s, task avg 518.547µs, min 454.7µs, max 32.5331ms
- finished in 13.2117127s, task avg 502.329µs, min 455.3µs, max 29.5416ms
- finished in 13.3526669s, task avg 507.706µs, min 455.1µs, max 59.3351ms
```